### PR TITLE
Always clear storm when using setter time mode

### DIFF
--- a/src/main/java/be/dezijwegel/bettersleeping/runnables/SleepersRunnable.java
+++ b/src/main/java/be/dezijwegel/bettersleeping/runnables/SleepersRunnable.java
@@ -60,7 +60,7 @@ public class SleepersRunnable extends BukkitRunnable {
             this.areAllPlayersSleeping = true;
         }
 
-        this.numNeeded = sleepersCalculator.getNumNeeded(this.world);
+        this.numNeeded = this.sleepersCalculator.getNumNeeded(this.world);
 
         int remaining = Math.max(this.numNeeded - this.sleepers.size() , 0);
 
@@ -76,15 +76,14 @@ public class SleepersRunnable extends BukkitRunnable {
             this.messenger.sendMessage(
                 this.world.getPlayers(),
                 "enough_sleeping",
+                new MsgEntry("<player>", ChatColor.stripColor(player.getDisplayName())),
                 new MsgEntry("<num_sleeping>", "" + this.sleepers.size()),
                 new MsgEntry("<needed_sleeping>", "" + this.numNeeded),
                 new MsgEntry("<remaining_sleeping>", "" + remaining)
             );
         } else if (this.sleepers.size() < this.numNeeded) {
-            List<Player> players = this.world.getPlayers();
-            players.remove(player);
             messenger.sendMessage(
-                players,
+                this.world.getPlayers(),
                 "bed_enter_broadcast",
                 new MsgEntry("<player>", ChatColor.stripColor(player.getDisplayName())),
                 new MsgEntry("<num_sleeping>", "" + this.sleepers.size()),
@@ -137,6 +136,7 @@ public class SleepersRunnable extends BukkitRunnable {
             this.messenger.sendMessage(
                 this.world.getPlayers(),
                 "skipping_canceled",
+                new MsgEntry("<player>", ChatColor.stripColor(player.getDisplayName())),
                 new MsgEntry("<num_sleeping>", "" + this.sleepers.size()),
                 new MsgEntry("<needed_sleeping>", "" + this.numNeeded),
                 new MsgEntry("<remaining_sleeping>", "" + remaining)

--- a/src/main/java/be/dezijwegel/bettersleeping/runnables/SleepersRunnable.java
+++ b/src/main/java/be/dezijwegel/bettersleeping/runnables/SleepersRunnable.java
@@ -2,15 +2,14 @@ package be.dezijwegel.bettersleeping.runnables;
 
 import be.dezijwegel.bettersleeping.events.custom.TimeSetToDayEvent;
 import be.dezijwegel.bettersleeping.interfaces.SleepersNeededCalculator;
-import be.dezijwegel.bettersleeping.messaging.MsgEntry;
 import be.dezijwegel.bettersleeping.messaging.Messenger;
+import be.dezijwegel.bettersleeping.messaging.MsgEntry;
 import be.dezijwegel.bettersleeping.sleepersneeded.AbsoluteNeeded;
 import be.dezijwegel.bettersleeping.timechange.TimeChanger;
 import be.dezijwegel.bettersleeping.util.SleepStatus;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.World;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -18,7 +17,6 @@ import org.bukkit.scheduler.BukkitRunnable;
 import java.util.*;
 
 public class SleepersRunnable extends BukkitRunnable {
-
     // Final data
     private final World world;
     private final Set<Player> sleepers;
@@ -34,77 +32,77 @@ public class SleepersRunnable extends BukkitRunnable {
     private long oldTime;
     private boolean areAllPlayersSleeping = false;
 
-
     /**
      * A runnable that will detect time changes and its cause
      */
-    public SleepersRunnable(World world, Messenger messenger, TimeChanger timeChanger, SleepersNeededCalculator sleepersCalculator)
-    {
+    public SleepersRunnable(World world, Messenger messenger, TimeChanger timeChanger, SleepersNeededCalculator sleepersCalculator) {
         this.world = world;
         this.messenger = messenger;
-        oldTime = world.getTime();
-
+        this.oldTime = world.getTime();
         this.timeChanger = timeChanger;
-
         this.sleepersCalculator = sleepersCalculator;
-        numNeeded = sleepersCalculator.getNumNeeded(world);
-
+        this.numNeeded = sleepersCalculator.getNumNeeded(world);
         this.sleepers = new HashSet<>();
         this.bedLeaveTracker = new HashMap<>();
     }
-
 
     /**
      * Mark a player as sleeping
      * A reference to the player will be stored
      * @param player the now sleeping player
      */
-    public void playerEnterBed(Player player)
-    {
-        sleepers.add(player);
-        bedLeaveTracker.remove(player);
+    public void playerEnterBed(Player player) {
+        this.sleepers.add(player);
+        this.bedLeaveTracker.remove(player);
 
         // Check whether all players are sleeping
-        if (sleepers.size() == world.getPlayers().size())
-            areAllPlayersSleeping = true;
+        if (this.sleepers.size() == this.world.getPlayers().size()) {
+            this.areAllPlayersSleeping = true;
+        }
 
-        numNeeded = sleepersCalculator.getNumNeeded(world);
+        this.numNeeded = sleepersCalculator.getNumNeeded(this.world);
 
-        int remaining = Math.max( numNeeded - sleepers.size() , 0);
+        int remaining = Math.max(this.numNeeded - this.sleepers.size() , 0);
 
-        messenger.sendMessage(player, "bed_enter_message",
-                new MsgEntry("<num_sleeping>",      "" + sleepers.size()),
-                new MsgEntry("<needed_sleeping>",   "" + numNeeded),
-                new MsgEntry("<remaining_sleeping>","" + remaining));
+        this.messenger.sendMessage(
+            player,
+            "bed_enter_message",
+            new MsgEntry("<num_sleeping>", "" + this.sleepers.size()),
+            new MsgEntry("<needed_sleeping>", "" + this.numNeeded),
+            new MsgEntry("<remaining_sleeping>", "" + remaining)
+        );
 
-
-        if (sleepers.size() == numNeeded)
-        {
-            messenger.sendMessage(world.getPlayers(), "enough_sleeping",
-                    new MsgEntry("<num_sleeping>",      "" + sleepers.size()),
-                    new MsgEntry("<needed_sleeping>",   "" + numNeeded),
-                    new MsgEntry("<remaining_sleeping>","" + remaining));
-        } else if (sleepers.size() < numNeeded) {
-            List<Player> players = world.getPlayers();
+        if (this.sleepers.size() == this.numNeeded) {
+            this.messenger.sendMessage(
+                this.world.getPlayers(),
+                "enough_sleeping",
+                new MsgEntry("<num_sleeping>", "" + this.sleepers.size()),
+                new MsgEntry("<needed_sleeping>", "" + this.numNeeded),
+                new MsgEntry("<remaining_sleeping>", "" + remaining)
+            );
+        } else if (this.sleepers.size() < this.numNeeded) {
+            List<Player> players = this.world.getPlayers();
             players.remove(player);
-            messenger.sendMessage(players, "bed_enter_broadcast",
-                    new MsgEntry("<player>", ChatColor.stripColor( player.getDisplayName() )),
-                    new MsgEntry("<num_sleeping>",      "" + sleepers.size()),
-                    new MsgEntry("<needed_sleeping>",   "" + numNeeded),
-                    new MsgEntry("<remaining_sleeping>","" + remaining));
+            messenger.sendMessage(
+                players,
+                "bed_enter_broadcast",
+                new MsgEntry("<player>", ChatColor.stripColor(player.getDisplayName())),
+                new MsgEntry("<num_sleeping>", "" + this.sleepers.size()),
+                new MsgEntry("<needed_sleeping>", "" + this.numNeeded),
+                new MsgEntry("<remaining_sleeping>", "" + remaining)
+            );
         }
     }
 
+    public SleepStatus getSleepStatus() {
+        int set = this.sleepersCalculator.getSetting();
+        String setting = ((this.sleepersCalculator instanceof AbsoluteNeeded)
+            ? "An absolute amount of players has to sleep: " + set
+            : set + "% of players needs to sleep"
+        );
 
-    public SleepStatus getSleepStatus()
-    {
-        int set = sleepersCalculator.getSetting();
-        String setting = (sleepersCalculator instanceof AbsoluteNeeded) ?   "An absolute amount of players has to sleep: " + set :
-                                                                            set + "% of players needs to sleep";
-
-        return new SleepStatus(sleepers.size(), numNeeded, world, timeChanger.getType(), setting);
+        return new SleepStatus(this.sleepers.size(), this.numNeeded, this.world, this.timeChanger.getType(), setting);
     }
-
 
     /**
      * Mark a player as awake
@@ -113,126 +111,120 @@ public class SleepersRunnable extends BukkitRunnable {
      */
     public void playerLeaveBed(Player player)
     {
-        if(areAllPlayersSleeping)
+        if (this.areAllPlayersSleeping) {
             return;
+        }
 
-        int previousSize = sleepers.size();
-        sleepers.remove(player);
-        bedLeaveTracker.put(player, world.getTime());
+        int previousSize = this.sleepers.size();
+        this.sleepers.remove(player);
+        this.bedLeaveTracker.put(player, this.world.getTime());
 
-        numNeeded = sleepersCalculator.getNumNeeded(world);
+        this.numNeeded = this.sleepersCalculator.getNumNeeded(this.world);
 
         // Don't send cancelled messages when the time is not right
-        if (world.getTime() < 20 || world.getTime() > 23450)
+        if (this.world.getTime() < 20 || this.world.getTime() > 23450) {
             return;
+        }
 
         // Check if enough players WERE sleeping but now not anymore
-        if (   sleepers.size() < previousSize
-            && previousSize >= numNeeded
-            && sleepers.size() < numNeeded
-            && !timeChanger.removedStorm(false))
-        {
-            int remaining = numNeeded - sleepers.size();
-            messenger.sendMessage(world.getPlayers(), "skipping_canceled",
-                    new MsgEntry("<num_sleeping>", "" + sleepers.size()),
-                    new MsgEntry("<needed_sleeping>", "" + numNeeded),
-                    new MsgEntry("<remaining_sleeping>", "" + remaining));
+        if (
+            this.sleepers.size() < previousSize &&
+            previousSize >= this.numNeeded &&
+            this.sleepers.size() < this.numNeeded &&
+            !this.timeChanger.removedStorm(false)
+        ) {
+            int remaining = this.numNeeded - this.sleepers.size();
+            this.messenger.sendMessage(
+                this.world.getPlayers(),
+                "skipping_canceled",
+                new MsgEntry("<num_sleeping>", "" + this.sleepers.size()),
+                new MsgEntry("<needed_sleeping>", "" + this.numNeeded),
+                new MsgEntry("<remaining_sleeping>", "" + remaining)
+            );
         }
     }
-
 
     /**
      * Delete the player from all internal lists
      * @param player the player to be deleted
      */
-    public void playerLogout(Player player)
-    {
-        playerLeaveBed(player);
-        bedLeaveTracker.remove(player);
+    public void playerLogout(Player player) {
+        this.playerLeaveBed(player);
+        this.bedLeaveTracker.remove(player);
 
         // Update the needed count when players leave their bed so that the count is adjusted
-        numNeeded = sleepersCalculator.getNumNeeded(world);
+        this.numNeeded = this.sleepersCalculator.getNumNeeded(this.world);
     }
-
 
     @Override
     public void run() {
-
-
-        /*/
-         *  TIME DETECTOR
-        /*/
-
+        // TIME DETECTOR
 
         // Time check subsystem: detect time set to day
-        long newTime = world.getTime();
+        long currentTime = this.world.getTime();
 
         // True if time is set to day OR the storm was skipped during the day
-        if ((newTime < 10 && newTime < oldTime) || (timeChanger.removedStorm(true) && newTime < 12000)) {
+        if (
+            (currentTime < 10 && currentTime < this.oldTime) ||
+            (this.timeChanger.removedStorm(true) && currentTime < 12000)
+        ) {
             // Find players who slept
-            if (areAllPlayersSleeping)
-            {
-                sleepers.addAll( world.getPlayers() );
-            }
-            else
-            {
-                for (Map.Entry<Player, Long> entry : bedLeaveTracker.entrySet())
-                {
-                    if ((entry.getValue() < 10) || (entry.getValue() >= 23450))
-                        sleepers.add(entry.getKey());
+            if (this.areAllPlayersSleeping) {
+                this.sleepers.addAll(this.world.getPlayers());
+            } else {
+                for (Map.Entry<Player, Long> entry : this.bedLeaveTracker.entrySet()) {
+                    if ((entry.getValue() < 10) || (entry.getValue() >= 23450)) {
+                        this.sleepers.add(entry.getKey());
+                    }
                 }
             }
 
-
             // Find the skip cause
             TimeSetToDayEvent.Cause cause;
-
-            if ( timeChanger.wasTimeSetToDay() )                // Caused by BetterSleeping?
+            if (timeChanger.wasTimeSetToDay()) { // Caused by BetterSleeping?
                 cause = TimeSetToDayEvent.Cause.SLEEPING;
-            else if ( areAllPlayersSleeping )                   // Caused by all players in a world sleeping -> Time is set to day instantly
+            } else if (areAllPlayersSleeping) { // Caused by all players in a world sleeping -> Time is set to day instantly
                 cause = TimeSetToDayEvent.Cause.SLEEPING;
-            else if ( newTime == 0 && oldTime == 23999 )        // Natural passing of time?
+            } else if (currentTime == 0 && oldTime == 23999) { // Natural passing of time?
                 cause = TimeSetToDayEvent.Cause.NATURAL;
-            else                                                // Caused by some time setter?
+            } else { // Caused by some time setter?
                 cause = TimeSetToDayEvent.Cause.OTHER;
-
-
-            if (cause != TimeSetToDayEvent.Cause.NATURAL)
-            {
-                // Send good morning, only when the players slept
-                messenger.sendMessage(world.getPlayers(), "morning_message");
             }
 
+            if (cause != TimeSetToDayEvent.Cause.NATURAL) {
+                // Send good morning, only when the players slept
+                messenger.sendMessage(this.world.getPlayers(), "morning_message");
+            }
 
             // Throw event for other devs to handle (and to handle buffs internally)
-            List<Player> nonSleepers = world.getPlayers();
-            nonSleepers.removeAll( sleepers );
-            Event timeSetToDayEvent = new TimeSetToDayEvent(world, cause, new ArrayList<>(sleepers), nonSleepers);
-            Bukkit.getPluginManager().callEvent( timeSetToDayEvent );
+            List<Player> nonSleepers = this.world.getPlayers();
+            nonSleepers.removeAll(this.sleepers);
+            Event timeSetToDayEvent = new TimeSetToDayEvent(world, cause, new ArrayList<>(this.sleepers), nonSleepers);
+            Bukkit.getPluginManager().callEvent(timeSetToDayEvent);
 
             // Reset state
-            areAllPlayersSleeping = false;
-            bedLeaveTracker.clear();
-            sleepers.clear();
+            this.areAllPlayersSleeping = false;
+            this.bedLeaveTracker.clear();
+            this.sleepers.clear();
         }
 
-        oldTime = newTime;
+        this.oldTime = currentTime;
 
-        // Early return if players can't sleep anyway
-        if (newTime < TimeChanger.TIME_RAIN_NIGHT && !world.isThundering())
+        // Early return if players can't sleep.
+        if (
+            currentTime < TimeChanger.TIME_RAIN_NIGHT ||
+            (!world.isThundering() && currentTime < TimeChanger.TIME_NIGHT)
+        ) {
             return;
+        }
 
-
-        /*/
-         *  SLEEP HANDLER
-        /*/
-
+        // SLEEP HANDLER
 
         // Make sure the set does not contain any false sleepers
-        sleepers.removeIf(player -> !player.isSleeping());
+        this.sleepers.removeIf(player -> !player.isSleeping());
 
-        if (sleepers.size() >= numNeeded)
-            timeChanger.tick(sleepers.size(), numNeeded);
-
+        if (this.sleepers.size() >= this.numNeeded) {
+            this.timeChanger.tick(this.sleepers.size(), this.numNeeded);
+        }
     }
 }

--- a/src/main/java/be/dezijwegel/bettersleeping/timechange/TimeSetter.java
+++ b/src/main/java/be/dezijwegel/bettersleeping/timechange/TimeSetter.java
@@ -3,60 +3,44 @@ package be.dezijwegel.bettersleeping.timechange;
 import org.bukkit.World;
 
 public class TimeSetter extends TimeChanger {
-
     private final int sleepDelay;
-
     private int counter = 0;
     private long oldTime;
 
-    public TimeSetter(World world, int delay)
-    {
+    public TimeSetter(World world, int delay) {
         super(world);
-        oldTime = world.getTime();
+        this.oldTime = world.getTime();
 
         // * 20 to convert seconds into ticks
-        sleepDelay = 20 * delay;
+        this.sleepDelay = 20 * delay;
     }
 
     @Override
-    public TimeChangeType getType()
-    {
+    public TimeChangeType getType() {
         return TimeChangeType.SETTER;
     }
 
     @Override
     public void tick(int numSleeping, int numNeeded) {
+        long currentTime = world.getTime();
 
-        // Handle the counter
-        long newTime = world.getTime();
-        counter = (newTime < oldTime + 5) ? counter + 1 : 0;
-        oldTime = newTime;
+        // Only increment counter when this tick is at most 5 ticks from the previous one. Reset otherwise.
+        this.counter = (currentTime < this.oldTime + 5) ? this.counter + 1 : 0;
+        this.oldTime = currentTime;
 
-        // Handle the time set mechanic when the counter reaches their set value
-        if (counter >= sleepDelay) {
-
-            // Reset the counter
-            counter = 0;
-
-            if (world.isThundering())
-            {
-                world.setThundering(false);
-                world.setStorm(false);
-                removedStorm = true;
-            }
-
-            if(newTime >= TIME_NIGHT)
-            {
-                world.setTime(TIME_MORNING);
-            }
-            else if (newTime >= TIME_RAIN_NIGHT && world.hasStorm())
-            {
-                world.setTime(TIME_MORNING);
-                world.setStorm(false);
-            }
-
-            // Mark time as set to day for parent
-            wasSetToDay = true;
+        // Wait for the sleep delay before doing anything.
+        if (this.counter < this.sleepDelay) {
+            return;
         }
+
+        // Reset the counter.
+        this.counter = 0;
+
+        // Perform night skip.
+        world.setStorm(false);
+        world.setTime(TimeChanger.TIME_MORNING);
+
+        // Mark time as set to day for parent
+        this.wasSetToDay = true;
     }
 }


### PR DESCRIPTION
Fixes #143 by always clearing storms when sleeping using the setter mode. Before it only cleared when storming and the time was between `TIME_RAIN_NIGHT` and `TIME_NIGHT` based on:

https://github.com/Nuytemans-Dieter/BetterSleeping/blob/b9190821b0e03782c5fd18ad96797f33943a5245/src/main/java/be/dezijwegel/bettersleeping/timechange/TimeSetter.java#L48-L56

I also fixed the early-out logic checking whether sleeping is possible at all, so that there doesn't need to be additional (correct) logic for that in `TimeSetter` itself.

https://github.com/Nuytemans-Dieter/BetterSleeping/blob/b9190821b0e03782c5fd18ad96797f33943a5245/src/main/java/be/dezijwegel/bettersleeping/runnables/SleepersRunnable.java#L221-L223

This logically allows ticking the `TimeChanger` at any time when it is thundering and without an upper limit if it is not thundering. Both are probably undesirable.

I used autoformat on the files I changed as a force of habit. I could undo that with some manual effort.

I've also added the `<player>` parameter to the `enough_sleeping` and `skipping_canceled` broadcasts, which closes #144. Note that I also changed `bed_enter_broadcast` to broadcast to _all_ players to be consistent. This might be undesirable, but I figured the player causing the broadcast would also like to know that they triggered one.