### PR TITLE
Translations for more Chinese variants

### DIFF
--- a/src/main/resources/lang/readme.md
+++ b/src/main/resources/lang/readme.md
@@ -13,6 +13,8 @@ Most of these are created by other server owners that are using BetterSleeping. 
 | Portuguese| pt-PT |
 | Dutch     | nl-BE |
 | Japanese  | ja-JP |
-| Chinese   | zh-ZH |
+| Chinese (Simplified)   | zh-CN |
+| Chinese (Traditional)   | zh-TW |
+| Chinese (Hong Kong Cantonese)    | zh-HK |
 | Russian   | ru-RU |
 | Silent mode | silent |

--- a/src/main/resources/lang/zh-cn.yml
+++ b/src/main/resources/lang/zh-cn.yml
@@ -1,0 +1,114 @@
+# ____       _   _            _____ _                 _                       ____
+#|  _ \     | | | |          / ____| |               (_)                     |___ \
+#| |_) | ___| |_| |_ ___ _ _| (___ | | ___  ___ _ __  _ _ __   __ _     __   ____) |
+#|  _ < / _ \ __| __/ _ \ '__\___ \| |/ _ \/ _ \ '_ \| | '_ \ / _` |    \ \ / /__ <
+#| |_) |  __/ |_| ||  __/ |  ____) | |  __/  __/ |_) | | | | | (_| |     \ V /___) |
+#|____/ \___|\__|\__\___|_| |_____/|_|\___|\___| .__/|_|_| |_|\__, |      \_/|____/
+#                                              | |             __/ |
+#                                              |_|            |___/
+
+# Default lang files: https://github.com/Nuytemans-Dieter/BetterSleeping/tree/v3.0.0/src/main/resources/lang
+
+# CONFIGURATION GUIDE:
+# The symbol '&' is used for color codes
+# Any message can be disabled by setting the text to "ignored" or "", an example can be found below
+# some_setting: "ignored"
+# another_setting: ""
+
+
+# SINGULAR / PLURAL
+# BetterSleeping supports singular and plural nouns
+# This requires 3 contents: a (supported!) placeholder that will be replaced by a number - the singular form - the plural form
+# Example: [<num_sleeping>.player.players] -> <num_sleeping> must be supported by the message and will be replaced by the corresponding amount
+#     When <num_sleeping> is equal to 1: everything between the [] will be replaced by player
+#     When <num_sleeping> is NOT equal to 1: everything between the [] will be replaced by players
+# Hint: You CAN use other placeholders (see below) in these singular/plural messages
+
+
+# PLACEHOLDERS
+# <user>
+#     Replaced by:      The player who receives the message
+#     Can be used in:   All messages support this
+#     Example:          When user Freddy_Krueger receives any message, <user> is replaced by Freddy_Krueger
+#
+# <player>
+#     Replaced by:      The player who did an action
+#     Can be used in:   bed_enter_broadcast
+#     Example:          When user Freddy_Krueger goes to bed, <player> is replaced by Freddy_Krueger
+#
+# <num_sleeping>
+#     Replaced by:      The amount of sleeping players
+#     Can be used in:   bed_enter_message, bed_enter_broadcast, enough_sleeping, skipping_canceled
+#     Example:          When user Freddy_Krueger receives any message, <user> is replaced by Freddy_Krueger
+#
+# <needed_sleeping>
+#     Replaced by:      The amount of sleeping players that have to sleep in order to skip the night
+#     Can be used in:   bed_enter_message, bed_enter_broadcast, enough_sleeping, skipping_canceled
+#     Example:          When 4 players need to sleep, <needed_sleeping> is replaced by 4
+#
+# <remaining_sleeping>
+#     Replaced by:      The amount of extra sleeping players that are needed
+#     Can be used in:   bed_enter_message, bed_enter_broadcast, enough_sleeping, skipping_canceled
+#     Example:          When 4 players are sleeping but 6 are needed, <remaining_sleeping> is replaced by 2
+#
+# <time>
+#     Replaced by:      The amount of time in a context
+#     Can be used in:   sleep_spam
+#     Example:          When a player has just left their bed and has to wait 4 seconds before they can enter it again, <time> is replaced by 4
+#
+# <var>
+#     Replaced by:      No_permission: the used command, buff_received: the amount of received buffs, debuff_received: the amount of received debuffs
+#     Can be used in:   no_permission, buff_received, debuff_received
+#     Example:          User executes /bs reload but has no access. <var> will be replaced by '/bs reload'
+
+
+# ----------------- #
+# Sleeping messages |
+# ----------------- #
+
+# A player receives this message when entering their bed
+bed_enter_message: "睡个好觉, <user>! (<num_sleeping>/<needed_sleeping>)"
+
+# All players in the same world get this message when someone enters their bed
+bed_enter_broadcast: "<player> 正在睡觉; 共有 <num_sleeping> 人正在睡觉; 仍需再有 <remaining_sleeping> 人睡觉。"
+
+# When not enough people are sleeping due to someone leaving their bed
+skipping_canceled: "有人离开了自己的床, 夜晚将不会被跳过! 需要再有 <remaining_sleeping> 人睡觉。"
+
+# This message is sent to all players in a world where enough players are sleeping
+enough_sleeping: "睡眠中的玩家人数已足, 夜晚将很快被跳过。"
+
+# Players receive this message in the morning
+morning_message: "早上好, <user>。祝一天愉快!"
+
+# Players that try to enter their bed too quickly after getting out of it
+sleep_spam: "你需要再等待 <time> 秒才能再次睡觉!"
+
+
+# --------------- #
+# Buffs & debuffs |
+# --------------- #
+
+# Players who slept AND receive buffs will get this message
+buff_received: "你休息得很好，获得了 <var> 种有益状态效果。"
+
+# Players who did not sleep AND receive debuffs will get this message
+debuff_received: "你没有睡觉，非常疲惫，因此获得了 <var> 种负面状态效果。"
+
+
+# -------------------- #
+# Commands/Permissions |
+# -------------------- #
+
+# The message a player gets when they don't have access to a command
+no_permission: "&c你没有执行 <var> 的权限!"
+
+# The message that will be sent to the admin that does a reload
+message_reloaded: "&2重新载入完成!"
+
+# This message is sent when a player tries to sleep but they have got a bypass permission
+# Permissions include:
+#     - Having the node bettersleeping.bypass OR essentials.sleepingignored
+#     - Being in a bypassed gamemode
+#     - Being afk / vanished
+bypass_message: "&c你在睡眠判定中被跳过了, 所以你不需要睡觉, <user>。"

--- a/src/main/resources/lang/zh-tw.yml
+++ b/src/main/resources/lang/zh-tw.yml
@@ -1,0 +1,115 @@
+# ____       _   _            _____ _                 _                       ____
+#|  _ \     | | | |          / ____| |               (_)                     |___ \
+#| |_) | ___| |_| |_ ___ _ _| (___ | | ___  ___ _ __  _ _ __   __ _     __   ____) |
+#|  _ < / _ \ __| __/ _ \ '__\___ \| |/ _ \/ _ \ '_ \| | '_ \ / _` |    \ \ / /__ <
+#| |_) |  __/ |_| ||  __/ |  ____) | |  __/  __/ |_) | | | | | (_| |     \ V /___) |
+#|____/ \___|\__|\__\___|_| |_____/|_|\___|\___| .__/|_|_| |_|\__, |      \_/|____/
+#                                              | |             __/ |
+#                                              |_|            |___/
+
+# Default lang files: https://github.com/Nuytemans-Dieter/BetterSleeping/tree/v3.0.0/src/main/resources/lang
+
+# CONFIGURATION GUIDE:
+# The symbol '&' is used for color codes
+# Any message can be disabled by setting the text to "ignored" or "", an example can be found below
+# some_setting: "ignored"
+# another_setting: ""
+
+
+# SINGULAR / PLURAL
+# BetterSleeping supports singular and plural nouns
+# This requires 3 contents: a (supported!) placeholder that will be replaced by a number - the singular form - the plural form
+# Example: [<num_sleeping>.player.players] -> <num_sleeping> must be supported by the message and will be replaced by the corresponding amount
+#     When <num_sleeping> is equal to 1: everything between the [] will be replaced by player
+#     When <num_sleeping> is NOT equal to 1: everything between the [] will be replaced by players
+# Hint: You CAN use other placeholders (see below) in these singular/plural messages
+
+
+# PLACEHOLDERS
+# <user>
+#     Replaced by:      The player who receives the message
+#     Can be used in:   All messages support this
+#     Example:          When user Freddy_Krueger receives any message, <user> is replaced by Freddy_Krueger
+#
+# <player>
+#     Replaced by:      The player who did an action
+#     Can be used in:   bed_enter_broadcast
+#     Example:          When user Freddy_Krueger goes to bed, <player> is replaced by Freddy_Krueger
+#
+# <num_sleeping>
+#     Replaced by:      The amount of sleeping players
+#     Can be used in:   bed_enter_message, bed_enter_broadcast, enough_sleeping, skipping_canceled
+#     Example:          When user Freddy_Krueger receives any message, <user> is replaced by Freddy_Krueger
+#
+# <needed_sleeping>
+#     Replaced by:      The amount of sleeping players that have to sleep in order to skip the night
+#     Can be used in:   bed_enter_message, bed_enter_broadcast, enough_sleeping, skipping_canceled
+#     Example:          When 4 players need to sleep, <needed_sleeping> is replaced by 4
+#
+# <remaining_sleeping>
+#     Replaced by:      The amount of extra sleeping players that are needed
+#     Can be used in:   bed_enter_message, bed_enter_broadcast, enough_sleeping, skipping_canceled
+#     Example:          When 4 players are sleeping but 6 are needed, <remaining_sleeping> is replaced by 2
+#
+# <time>
+#     Replaced by:      The amount of time in a context
+#     Can be used in:   sleep_spam
+#     Example:          When a player has just left their bed and has to wait 4 seconds before they can enter it again, <time> is replaced by 4
+#
+# <var>
+#     Replaced by:      No_permission: the used command, buff_received: the amount of received buffs, debuff_received: the amount of received debuffs
+#     Can be used in:   no_permission, buff_received, debuff_received
+#     Example:          User executes /bs reload but has no access. <var> will be replaced by '/bs reload'
+
+
+# ----------------- #
+# Sleeping messages |
+# ----------------- #
+
+# A player receives this message when entering their bed
+bed_enter_message: "睡個好覺, <user>! (<num_sleeping>/<needed_sleeping>)"
+
+# All players in the same world get this message when someone enters their bed
+bed_enter_broadcast: "<player> 正在睡覺; 共有 <num_sleeping> 人正在睡覺; 仍需再有 <remaining_sleeping> 人睡覺。"
+
+# When not enough people are sleeping due to someone leaving their bed
+skipping_canceled: "有人離開了自己的床, 夜晚將不會被跳過! 需要再有 <remaining_sleeping> 人睡覺!"
+
+# This message is sent to all players in a world where enough players are sleeping
+enough_sleeping: "睡眠中的玩家人數已足, 夜晚將很快被跳過。"
+
+# Players receive this message in the morning
+morning_message: "早上好, <user>。祝一天愉快!"
+
+# Players that try to enter their bed too quickly after getting out of it
+sleep_spam: "你需要再等待 <time> 秒才能再睡!"
+
+
+
+# --------------- #
+# Buffs & debuffs |
+# --------------- #
+
+# Players who slept AND receive buffs will get this message
+buff_received: "你休息得很好，獲得了 <var> 種有益狀態效果。"
+
+# Players who did not sleep AND receive debuffs will get this message
+debuff_received: "你没有睡覺，非常疲憊，因此獲得了 <var> 種負面狀態效果。"
+
+
+# -------------------- #
+# Commands/Permissions |
+# -------------------- #
+
+# The message a player gets when they don't have access to a command
+no_permission: "&c你没有執行 <var> 的權限!"
+
+# The message that will be sent to the admin that does a reload
+message_reloaded: "&2重新載入完成!"
+
+# This message is sent when a player tries to sleep but they have got a bypass permission
+# Permissions include:
+#     - Having the node bettersleeping.bypass OR essentials.sleepingignored
+#     - Being in a bypassed gamemode
+#     - Being afk / vanished
+bypass_message: "&c你在睡眠判定中被跳過了, 所以你不需要睡覺, <user>。"


### PR DESCRIPTION
Added Simplified Chinese (China) and Traditional Chinese (Taiwan) translations. 

Also, I noticed that the `zh-hk.yml` is actually Cantonese (a Chinese dialect) used in Hong Kong; this should be clarified in the description.