### PR TITLE
Fixed typo in pt-pt.yml file

### DIFF
--- a/src/main/resources/lang/pt-pt.yml
+++ b/src/main/resources/lang/pt-pt.yml
@@ -98,7 +98,7 @@ sleep_spam: "Você precisa esperar mais <time> [<time>.segundo.segundos] para qu
 buff_received: "Você dormiu bem e recebeu [<var>.um buff.<var> buffs]!"
 
 # Players who did not sleep AND receive debuffs will get this message
-debuff_received: "Você não dormiu e se sente cançado, você recebeu [<var>.um buff.<var> buffs]!"
+debuff_received: "Você não dormiu e se sente cansado, você recebeu [<var>.um buff.<var> buffs]!"
 
 
 # -------------------- #


### PR DESCRIPTION
Fixed typo in line 101: should be "cansado", and not "cançado".