### PR TITLE
Actually ignore cancelled events.

### DIFF
--- a/src/main/java/be/betterplugins/bettersleeping/listeners/BedEventListener.java
+++ b/src/main/java/be/betterplugins/bettersleeping/listeners/BedEventListener.java
@@ -62,7 +62,7 @@ public class BedEventListener implements Listener
     /**
      * Highest priority to call this method as late as possible, this gives other plugins the chance to cancel the event
      */
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onSleep(PlayerBedEnterEvent event)
     {
         // Only handle sleeping in enabled worlds


### PR DESCRIPTION
The docs state that this event can be cancelled by other plugins. However it does never check if the event is actually canceled nor does it ignore the event if it was cancelled already.

In the current state BetterSleeping just ignored the fact that the event was cancelled. This is fixed by setting `ignoreCancelled` to true which is false by default.