### PR TITLE
feature for punishing disconnected players before sleeping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,18 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
 
+
+        <repository>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
+        </repository>
+
+
         <!-- ESSENTIALS -->
         <repository>
-            <id>essentialsx</id>
-            <url>https://repo.essentialsx.net/releases/</url>
+            <id>essentialsx-releases</id>
+            <name>EssentialsX API Repository</name>
+            <url>https://repo.essentialsx.net/releases</url>
         </repository>
 
         <!-- PAPI -->


### PR DESCRIPTION
Currently players can avoid getting debuffs for not sleeping by disconnecting while/before other players are sleeping. This is unfair because players that stayed on the server and didnt sleep get the debuffs but the players that disconnected right before and joined in after a couple of seconds essentially dode sleeping penalties.

This feature aims at detecting players doing this and ensures that the players still get the debuffs when they reconnect.

It works by comparing the number of nights people have slept on the server by the time the player disconnects. when the player connects again it will check if there was a another sleeping cycle and if yes it will punish the player for not sleeping that night.